### PR TITLE
Fix async society token counter

### DIFF
--- a/owl/utils/enhanced_role_playing.py
+++ b/owl/utils/enhanced_role_playing.py
@@ -509,9 +509,10 @@ async def arun_society(
     input_msg = society.init_chat(init_prompt)
     for _round in range(round_limit):
         assistant_response, user_response = await society.astep(input_msg)
-        overall_prompt_token_count += assistant_response.info["usage"][
-            "completion_tokens"
-        ]
+        overall_completion_token_count += (
+            assistant_response.info["usage"]["completion_tokens"]
+            + user_response.info["usage"]["completion_tokens"]
+        )
         overall_prompt_token_count += (
             assistant_response.info["usage"]["prompt_tokens"]
             + user_response.info["usage"]["prompt_tokens"]


### PR DESCRIPTION
## Summary
- fix incorrect token accounting in `arun_society`

## Testing
- `ruff check --fix owl/utils/enhanced_role_playing.py`
- `ruff format owl/utils/enhanced_role_playing.py`
- `mypy --namespace-packages -p owl` *(fails: Library stubs not installed for "requests")*
- `python licenses/update_license.py . licenses/license_template.txt`

------
https://chatgpt.com/codex/tasks/task_e_68419d9b8220832e9f76460cf8e684e2